### PR TITLE
Reuse FhirContext in result serialization

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/mcp/CallToolResultFactory.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mcp/CallToolResultFactory.java
@@ -5,17 +5,23 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
+@Component
 public class CallToolResultFactory {
 
-	public static McpSchema.CallToolResult success(
+	@Autowired
+	private FhirContext fhirContext;
+
+	public McpSchema.CallToolResult success(
 			String resourceType, Interaction interaction, Object response, int status) {
 		Map<String, Object> payload = Map.of(
 				"resourceType", resourceType,
 				"interaction", interaction,
-				"response", FhirContext.forR4().newJsonParser().encodeResourceToString((IBaseResource) response),
+				"response", fhirContext.newJsonParser().encodeResourceToString((IBaseResource) response),
 				"status", status);
 
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -31,7 +37,7 @@ public class CallToolResultFactory {
 				.build();
 	}
 
-	public static McpSchema.CallToolResult failure(String message) {
+	public McpSchema.CallToolResult failure(String message) {
 		return McpSchema.CallToolResult.builder()
 				.isError(true)
 				.addTextContent(message)

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mcp/McpServerConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mcp/McpServerConfig.java
@@ -22,8 +22,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class McpServerConfig implements WebMvcConfigurer {
 
 	@Bean
-	public MCPBridge mcpBridge(RestfulServer restfulServer) {
-		return new MCPBridge(restfulServer);
+	public MCPBridge mcpBridge(RestfulServer restfulServer, CallToolResultFactory callToolResultFactory) {
+		return new MCPBridge(restfulServer, callToolResultFactory);
 	}
 
 	@Bean

--- a/src/main/java/ca/uhn/fhir/rest/server/MCPBridge.java
+++ b/src/main/java/ca/uhn/fhir/rest/server/MCPBridge.java
@@ -6,7 +6,6 @@ import ca.uhn.fhir.jpa.starter.mcp.Interaction;
 import ca.uhn.fhir.jpa.starter.mcp.RequestBuilder;
 import ca.uhn.fhir.jpa.starter.mcp.ToolFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -23,11 +22,12 @@ public class MCPBridge {
 
 	private final RestfulServer restfulServer;
 	private final FhirContext fhirContext;
-	private final ObjectMapper mapper = new ObjectMapper();
+	private final CallToolResultFactory callToolResultFactory;
 
-	public MCPBridge(RestfulServer restfulServer) {
+	public MCPBridge(RestfulServer restfulServer, CallToolResultFactory callToolResultFactory) {
 		this.restfulServer = restfulServer;
 		this.fhirContext = restfulServer.getFhirContext();
+		this.callToolResultFactory = callToolResultFactory;
 	}
 
 	public List<McpServerFeatures.SyncToolSpecification> generateTools() {
@@ -81,13 +81,13 @@ public class MCPBridge {
 				}
 				IBaseResource parsed = fhirContext.newJsonParser().parseResource(body);
 
-				return CallToolResultFactory.success(
+				return callToolResultFactory.success(
 						contextMap.get("resourceType").toString(), interaction, parsed, status);
 			} else {
-				return CallToolResultFactory.failure(String.format("FHIR server error %d: %s", status, body));
+				return callToolResultFactory.failure(String.format("FHIR server error %d: %s", status, body));
 			}
 		} catch (IOException e) {
-			return CallToolResultFactory.failure("Dispatch error: " + e.getMessage());
+			return callToolResultFactory.failure("Dispatch error: " + e.getMessage());
 		} catch (Exception e) {
 			return McpSchema.CallToolResult.builder()
 					.isError(true)


### PR DESCRIPTION
To make the MCP server work with R5